### PR TITLE
Replace template README with instructions for getting off the ground

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,30 @@
-# README
+# Hi!
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+[feedyour.email](https://feedyour.email) lets you send newsletters to your feed reader by generating an email address that aggregates messages into an Atom feed.
 
-Things you may want to cover:
+## Getting Started
 
-* Ruby version
+``` sh
+brew install chruby ruby-install postgresql redis
+ruby-install ruby 3.1.0
 
-* System dependencies
+# fish users: `brew install chruby-fish` instead
+source $HOMEBREW_PREFIX/opt/chruby/share/chruby/chruby.sh
 
-* Configuration
+chruby 3.1.0
+bundle install
+brew services start postgresql
+brew services start redis
+bin/rails db:create db:migrate db:seed
+bin/dev
+```
 
-* Database creation
+## Pushing Posts via the Email Webhook
 
-* Database initialization
+`db:seed` creates a feed named somefeed ([localhost:3000/feeds/somefeed](http://localhost:3000/feeds/somefeed)) with a post named somepost ([localhost:3000/posts/somepost](http://localhost:3000/posts/somepost)) but you can also add posts yourself using `curl`. An example email is checked into the respository and can be loaded by running:
 
-* How to run the test suite
+``` sh
+curl -vvv http://localhost:3000/email/incoming -d "@spec/support/body.json" -H "Content-Type: application/json"
+```
 
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+For convenience, emails with `To:` headers that don't match a feed will be added to the newest feed when `Rails.env.development?`.


### PR DESCRIPTION
Could probably also use some testing instructions but that would require tests.