### PR TITLE
Raise an exception if the feed is not recognized in the email webhook

### DIFF
--- a/app/processors/email_processor.rb
+++ b/app/processors/email_processor.rb
@@ -5,7 +5,7 @@ class EmailProcessor
   end
 
   def process(token: nil)
-    return unless feed
+    raise unless feed
 
     Post.create!(feed: feed, payload: @email.to_h, token: token)
   end


### PR DESCRIPTION
In general it seems like we should fail in the email processor whenever a webook call does not result in a post getting added to a feed. This allows us to track issues from Postmark, as well as retry delivery.

Could use a test but didn't want to wait.