### PR TITLE
Index and enforce uniqueness on tokens

### DIFF
--- a/db/migrate/20220115193900_unique_indexes_for_tokens.rb
+++ b/db/migrate/20220115193900_unique_indexes_for_tokens.rb
@@ -1,0 +1,6 @@
+class UniqueIndexesForTokens < ActiveRecord::Migration[7.0]
+  def change
+    add_index :feeds, :token, unique: true
+    add_index :posts, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_13_200808) do
+ActiveRecord::Schema.define(version: 2022_01_15_193900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2022_01_13_200808) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name"
+    t.index ["token"], name: "index_feeds_on_token", unique: true
   end
 
   create_table "posts", force: :cascade do |t|
@@ -31,6 +32,7 @@ ActiveRecord::Schema.define(version: 2022_01_13_200808) do
     t.citext "token", null: false
     t.index ["feed_id", "updated_at"], name: "index_posts_on_feed_id_and_updated_at", order: { updated_at: :desc }
     t.index ["feed_id"], name: "index_posts_on_feed_id"
+    t.index ["token"], name: "index_posts_on_token", unique: true
   end
 
 end

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -11,17 +11,14 @@ RSpec.describe Feed, type: :model do
     expect(feed.token).to eq(nil)
     expect { feed.save! }.to change { feed.token }
   end
-  
+
   it "enforces uniqueness on tokens" do
     conflicting_feed = Feed.new
     conflicting_feed.token = "somefeed"
     conflicting_feed.save!
 
-    feed.token = "somefeed"
-    expect { feed.save! }.to raise_error(ActiveRecord::RecordNotUnique)
-
-    feed.name = "SomeFeed"
-    expect { feed.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+    expect { feed.update!(token: "somefeed") }.to raise_error(ActiveRecord::RecordNotUnique)
+    expect { feed.update!(token: "SomeFeed") }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 
   it "uses the token in a fallback name" do

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Feed, type: :model do
     expect(feed.token).to eq(nil)
     expect { feed.save! }.to change { feed.token }
   end
+  
+  it "enforces uniqueness on tokens" do
+    conflicting_feed = Feed.new
+    conflicting_feed.token = "somefeed"
+    conflicting_feed.save!
+
+    feed.token = "somefeed"
+    expect { feed.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+
+    feed.name = "SomeFeed"
+    expect { feed.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
 
   it "uses the token in a fallback name" do
     feed.token = "abc123"

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -23,11 +23,8 @@ RSpec.describe Post, type: :model do
     conflicting_post.token = "somepost"
     conflicting_post.save!
 
-    post.token = "somepost"
-    expect { post.save! }.to raise_error(ActiveRecord::RecordNotUnique)
-
-    post.token = "SomePost"
-    expect { post.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+    expect { post.update!(token: "somepost") }.to raise_error(ActiveRecord::RecordNotUnique)
+    expect { post.update!(token: "SomePost") }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 
   it "has a from" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe Post, type: :model do
     expect { post.save! }.to change { post.token }
   end
 
+  it "enforces uniqueness on tokens" do
+    conflicting_post = Post.new(feed: Feed.new)
+    conflicting_post.token = "somepost"
+    conflicting_post.save!
+
+    post.token = "somepost"
+    expect { post.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+
+    post.token = "SomePost"
+    expect { post.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
   it "has a from" do
     post.payload = {"from" => {"full" => "person"}}
     expect(post.from).to eq("person")


### PR DESCRIPTION
As unlikely as it is to happen, it's nice to have collision protection on tokens at the database layer. Also: apparently we've been doing unindexed queries when fetching feeds/posts by token this whole time?