### PR TITLE
Atom feed's root_url is /feed/posts not /feed/show

### DIFF
--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -1,4 +1,3 @@
-<% content_for :page_favicon, @feed.favicon_url %>
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
   <div class="text-center">
     <h2 class="text-base font-semibold text-indigo-600 tracking-wide uppercase">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_favicon, @feed.favicon_url %>
 <div class="mx-auto">
   <p class="text-center my-1 text-4xl font-extrabold text-gray-900 sm:text-5xl sm:tracking-tight lg:text-6xl">
     <%= @feed.name %>


### PR DESCRIPTION
So that's where the favicon actually needs to go for RSS readers to have a chance at picking it up.
