### PR TITLE
Fix processing for emails with FYE in cc or bcc

### DIFF
--- a/app/mailboxes/post_mailbox.rb
+++ b/app/mailboxes/post_mailbox.rb
@@ -27,7 +27,7 @@ class PostMailbox < ApplicationMailbox
   end
 
   def feed_token
-    mail.to_addresses.find { |a| a.domain == "feedyour.email" }&.local ||
+    mail.recipients_addresses.find { |a| a.domain == "feedyour.email" }&.local ||
       raise("Unknown address #{mail.to_addresses.inspect}")
   end
 


### PR DESCRIPTION
[For example](https://account.postmarkapp.com/servers/8531948/streams/inbound/messages/e2cb23bc-0c54-4d15-b791-bb63b17af50e).

Luckily rails already [has API](https://www.rubydoc.info/docs/rails/Mail%2FMessage:recipients_addresses) for this.