### PR TITLE
Remove Redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem "nilify_blanks", "~> 1.4"
 gem "propshaft", "~> 0.8.0"
 gem "puma", "~> 6.4"
 gem "rack-canonical-host", "~> 1.2", require: false
-gem "redis", "~> 5.0"
 gem "sqlite3", "~> 1.7"
 gem "tailwindcss-rails", "~> 2.2"
 gem "turbo-rails", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,10 +303,6 @@ GEM
       ffi (~> 1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
-    redis (5.0.8)
-      redis-client (>= 0.17.0)
-    redis-client (0.17.1)
-      connection_pool
     regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
@@ -452,7 +448,6 @@ DEPENDENCIES
   puma (~> 6.4)
   rack-canonical-host (~> 1.2)
   rails (~> 7.1)
-  redis (~> 5.0)
   rspec-rails (~> 6.1)
   rubocop-gemfile (~> 0.1.0.beta3)
   rubocop-rails (~> 2.23)

--- a/bin/setup
+++ b/bin/setup
@@ -10,8 +10,7 @@ end
 
 FileUtils.chdir APP_ROOT do
   puts "== Installing Homebrew dependencies =="
-  system! "brew install chruby ruby-install sqlite redis"
-  system! "brew services start redis"
+  system! "brew install chruby ruby-install sqlite"
 
   puts "== Installing Ruby =="
   unless `bundle platform` =~ /current platform satisfies/

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,11 +1,8 @@
 development:
-  adapter: redis
-  url: redis://localhost:6379/1
+  adapter: async
 
 test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: feedyour_email_production
+  adapter: async

--- a/config/dockerfile.yml
+++ b/config/dockerfile.yml
@@ -6,7 +6,5 @@ options:
   label:
     fly_launch_runtime: rails
   parallel: true
-  postgresql: false
   sqlite: true
-  prepare: false
-  redis: true
+  prepare: true


### PR DESCRIPTION
This PR (when applied on top of #364 and #365) will remove the external service dependency on Redis. It turns out ActionCable works just fine with in-memory storage if you only have one Ruby process, and we do.

I mean, we were also only using it for fancy websocket-based real-time updates to web pages when new emails arrived, so it seems kind of silly to have an entire external service just for that.