### PR TITLE
Resolve a weird encoding edge case

### DIFF
--- a/app/mailboxes/post_mailbox.rb
+++ b/app/mailboxes/post_mailbox.rb
@@ -52,11 +52,11 @@ class PostMailbox < ApplicationMailbox
 
   def text_body
     return mail.text_part.decoded if mail.text_part
-    (mail.mime_type == "text/plain") ? mail.body.decoded : nil
+    (mail.mime_type == "text/plain") ? mail.decoded : nil
   end
 
   def html_body
     return mail.html_part.decoded if mail.html_part
-    (mail.mime_type == "text/html") ? mail.body.decoded : nil
+    (mail.mime_type == "text/html") ? mail.decoded : nil
   end
 end


### PR DESCRIPTION
So the Mail object knows that its charset is iso-8859-1. But somehow the `body` object thinks it is already encoded in UTF-8, when it is not. Because of this, calling `decoded` will actually convert the mail body to UTF-8. Due to this weird situation, calling `body.decoded` will actually return a string that _says_ it is encoded UTF-8, but it actually is not, and that will cause errors later.

HOW

WHY

[101] pry(#<Mail::Message>):1> charset
=> "iso-8859-1"
[102] pry(#<Mail::Message>):1> body.charset
=> "UTF-8"
