### PR TITLE
Add cache headers to feeds

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -5,6 +5,8 @@ class FeedsController < ApplicationController
 
   def show
     @feed = Feed.find_by!(token: params[:id])
+    fresh_when(@feed)
+
     @feed.touch(:fetched_at) unless @feed.expired_at? || request.format.html?
   end
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -11,7 +11,7 @@ class FeedsController < ApplicationController
     return http_cache_forever(public: true) if feed.expired?
 
     fresh_when @feed
-    expires_in 1.hour, public: true
+    expires_in 1.hour, public: true if @feed.created_at < 1.day.ago
   end
 
   def create

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -5,6 +5,7 @@ class FeedsController < ApplicationController
 
   def show
     @feed = Feed.find_by!(token: params[:id])
+    expires_in 1.hour, public: true
     fresh_when(@feed)
 
     @feed.touch(:fetched_at) unless @feed.expired_at? || request.format.html?

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -5,10 +5,12 @@ class FeedsController < ApplicationController
 
   def show
     @feed = Feed.find_by!(token: params[:id])
-    expires_in 1.hour, public: true
-    fresh_when(@feed)
+    return if request.format.html?
 
-    @feed.touch(:fetched_at) unless @feed.expired_at? || request.format.html?
+    @feed.fetch_or_expire!
+
+    fresh_when @feed
+    expires_in 1.hour, public: true
   end
 
   def create

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -8,7 +8,7 @@ class FeedsController < ApplicationController
     return if request.format.html?
 
     @feed.fetch_or_expire!
-    return http_cache_forever(public: true) if feed.expired?
+    return http_cache_forever(public: true) if feed.expired_at?
 
     fresh_when @feed
     expires_in 1.hour, public: true if @feed.created_at < 1.day.ago

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -8,7 +8,7 @@ class FeedsController < ApplicationController
     return if request.format.html?
 
     @feed.fetch_or_expire!
-    return http_cache_forever(public: true) if feed.expired_at?
+    return http_cache_forever(public: true) if @feed.expired_at?
 
     fresh_when @feed
     expires_in 1.hour, public: true if @feed.created_at < 1.day.ago

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -8,6 +8,7 @@ class FeedsController < ApplicationController
     return if request.format.html?
 
     @feed.fetch_or_expire!
+    return http_cache_forever(public: true) if feed.expired?
 
     fresh_when @feed
     expires_in 1.hour, public: true

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -64,8 +64,10 @@ class Feed < ApplicationRecord
     create_post("warning", "Feed usage warning") if week_posts.count == 10
   end
 
-  def expire_if_stale!
-    update!(expired_at: Time.current) if expired_at.nil? && stale?
+  def fetch_or_expire!
+    return if expired_at
+
+    stale? ? touch(:expired_at) : touch(:fetched_at)
   end
 
   def stale?

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -67,7 +67,13 @@ class Feed < ApplicationRecord
   def fetch_or_expire!
     return if expired_at
 
+    save! if new_record?
     stale? ? touch(:expired_at) : touch(:fetched_at)
+  end
+
+  def expire_if_stale!
+    save! if new_record?
+    touch(:expired_at) if stale?
   end
 
   def stale?

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe FeedsController, type: :controller do
   end
 
   describe "#show" do
+    before do
+      Feed.find_or_create_by!(token: "abc123")
+    end
+
     it "succeeds" do
       get :show, params: {id: "abc123"}
       expect(response).to be_successful

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -20,5 +20,15 @@ RSpec.describe FeedsController, type: :controller do
       get :show, params: {id: "abc123"}
       expect(response).to be_successful
     end
+
+    it "succeeds with json" do
+      get :show, params: {id: "abc123"}, format: :json
+      expect(response).to be_successful
+    end
+
+    it "succeeds with atom" do
+      get :show, params: {id: "abc123"}, format: :atom
+      expect(response).to be_successful
+    end
   end
 end

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe FeedsController, type: :controller do
   describe "#new" do

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe FeedsController, type: :controller do
+  describe "#new" do
+    it "succeeds" do
+      get :new
+      expect(response).to be_successful
+    end
+  end
+
+  describe "#create" do
+    it "suceeds and redirects" do
+      post :create, params: {name: "Some name"}
+      expect(response).to be_redirect
+    end
+  end
+
+  describe "#show" do
+    it "succeeds" do
+      get :show, params: {id: "abc123"}
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
Adds some useful headers:
- etag (checksum of feed contents)
- last-modified (timestamp last post was added to feed)
- cache-control (tell clients to cache every request for 1 hour, after feeds are 24 hours old)

Adds some useful behavior:
- on feed fetch, mark feed as expired if 3 months since last fetch
- on new email, mark feed as expired if 3 months since last fetch
- cache expired feeds forever, since we will not update them anymore