### PR TITLE
Make GHA backup action actually work

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -18,16 +18,18 @@ jobs:
         id: filename
         run: |
           CURRENT_DATE=$(date +"%Y-%m-%d_%H-%M-%S")
-          echo "filename=backup_${CURRENT_DATE}.gz" >> "$GITHUB_OUTPUT"
+          echo "filename=backup_${CURRENT_DATE}" >> "$GITHUB_OUTPUT"
       - name: Setup Fly.io CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Fetch backup from Fly.io
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
-          flyctl -a ${{ env.FLY_APP_NAME }} ssh sftp get /rails/storage/production/backup.sqlite3.gzip ${{ steps.filename.outputs.filename }}
+          flyctl -a ${{ env.FLY_APP_NAME }} ssh sftp get /rails/storage/production/backup.sqlite3 ${{ steps.filename.outputs.filename }}
+      - name: Compress backup
+        run: gzip ${{ steps.filename.outputs.filename }}
       - name: Upload compressed backup as GitHub artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.filename.outputs.filename }}
-          path: ${{ steps.filename.outputs.filename }}
+          name: ${{ steps.filename.outputs.filename }}.gz
+          path: ${{ steps.filename.outputs.filename }}.gz

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           flyctl -a ${{ env.FLY_APP_NAME }} ssh sftp get /rails/storage/production/backup.sqlite3.gzip ${{ steps.filename.outputs.filename }}
       - name: Upload compressed backup as GitHub artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.filename.outputs.filename }}
           path: ${{ steps.filename.outputs.filename }}

--- a/app/lib/database_backup.rb
+++ b/app/lib/database_backup.rb
@@ -4,19 +4,18 @@ class DatabaseBackup
   end
 
   def run
-    `sqlite3 #{Shellwords.escape db_path} "VACUUM INTO '#{Shellwords.escape backup_path}'"`
-    `gzip -f9 #{Shellwords.escape backup_path}`
-
-    "#{backup_path}.gzip"
+    FileUtils.rm_rf backup_path
+    conn.execute "VACUUM INTO #{conn.quote(backup_path.to_s)}"
+    backup_path
   end
 
   private
 
-  def db_path
-    Rails.root.join "storage", Rails.env, "data.sqlite3" # rubocop:disable Lint/Env
+  def conn
+    ActiveRecord::Base.connection
   end
 
   def backup_path
-    Rails.root.join "storage", Rails.env, "backup.sqlite3" # rubocop:disable Lint/Env
+    Rails.root.join("storage", Rails.env, "backup.sqlite3") # rubocop:disable Lint/Env
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,7 @@ Rails.application.routes.draw do
   end
   resources :stats, only: [:index]
 
+  get "up" => "rails/health#show"
+
   root "feeds#new"
 end

--- a/fly.toml
+++ b/fly.toml
@@ -23,7 +23,7 @@ console_command = "/rails/bin/rails console"
 
 [[vm]]
   cpu_kind = "shared"
-  cpus = 1
+  cpus = 2
   memory_mb = 1024
 
 [[statics]]

--- a/fly.toml
+++ b/fly.toml
@@ -26,6 +26,20 @@ console_command = "/rails/bin/rails console"
   cpus = 2
   memory_mb = 1024
 
+[checks]
+  [checks.rails]
+    processes = ["app"]
+    grace_period = "30s"
+    interval = "15s"
+    method = "get"
+    path = "/up"
+    port = 3000
+    timeout = "10s"
+    type = "http"
+    [checks.rails.headers]
+      Host = "feedyour.email"
+      X-Forwarded-Proto = "https"
+
 [[statics]]
   guest_path = "/rails/public"
   url_prefix = "/"


### PR DESCRIPTION
- we were using a removed old version of `actions/upload-artifact`
- we were shelling out to `sqlite3`, which isn't present on the fly VM
- we were gzipping on the Fly VM, which is more resource constrained than a GHA worker
- we had no fly health check for some reason, so I added one. I hope.